### PR TITLE
feat: add Lingui v5 macro split codemod

### DIFF
--- a/codemods/sample-jssg-codemod/codemod.yaml
+++ b/codemods/sample-jssg-codemod/codemod.yaml
@@ -1,17 +1,17 @@
 schema_version: "1.0"
 
-name: "jssg-codemod"
-version: "0.1.0"
-description: "Transform legacy code patterns"
-author: "Author <author@example.com>"
+name: "lingui-macro-split"
+version: "1.0.0"
+description: "Migrate from deprecated @lingui/macro to split @lingui/react/macro and @lingui/core/macro packages"
+author: "Lingui Migration Team"
 license: "MIT"
 workflow: "workflow.yaml"
 category: "migration"
 
 targets:
-  languages: ["typescript"]
+  languages: ["typescript", "javascript"]
 
-keywords: ["transformation", "migration"]
+keywords: ["lingui", "i18n", "internationalization", "migration", "macro", "react"]
 
 registry:
   access: "public"

--- a/codemods/sample-jssg-codemod/scripts/codemod.ts
+++ b/codemods/sample-jssg-codemod/scripts/codemod.ts
@@ -1,23 +1,117 @@
 import type { SgRoot } from "codemod:ast-grep";
 import type TS from "codemod:ast-grep/langs/typescript";
 
+// React macro components that should be imported from @lingui/react/macro
+const REACT_MACROS = new Set([
+	"Trans",
+	"Plural",
+	"Select",
+	"SelectOrdinal",
+	"I18n",
+	"Date",
+	"Number",
+	"Time",
+	"RelativeTime",
+]);
+
+// Core macro functions that should be imported from @lingui/core/macro
+const CORE_MACROS = new Set([
+	"t",
+	"msg",
+	"plural",
+	"select",
+	"selectOrdinal",
+	"i18n",
+	"date",
+	"number",
+	"time",
+	"relativeTime",
+]);
+
 async function transform(root: SgRoot<TS>): Promise<string> {
 	const rootNode = root.root();
+	const edits: any[] = [];
 
-	const nodes = rootNode.findAll({
+	// Find all import declarations from @lingui/macro
+	const importNodes = rootNode.findAll({
 		rule: {
-			pattern: "var $VAR = $VALUE",
+			pattern: 'import $IMPORTS from "@lingui/macro"',
 		},
 	});
 
-	const edits = nodes.map((node) => {
-		const varName = node.getMatch("VAR")?.text();
-		const value = node.getMatch("VALUE")?.text();
-		return node.replace(`const ${varName} = ${value}`);
-	});
+	// Process each import statement
+	for (const importNode of importNodes) {
+		const importsText = importNode.getMatch("IMPORTS")?.text();
+		if (!importsText) continue;
+
+		// Parse the import specifiers
+		const specifiers = parseImportSpecifiers(importsText);
+		
+		// Separate React and core macros
+		const reactSpecifiers: string[] = [];
+		const coreSpecifiers: string[] = [];
+		const otherSpecifiers: string[] = [];
+
+		for (const spec of specifiers) {
+			const name = spec.name;
+			if (REACT_MACROS.has(name)) {
+				reactSpecifiers.push(spec.full);
+			} else if (CORE_MACROS.has(name)) {
+				coreSpecifiers.push(spec.full);
+			} else {
+				otherSpecifiers.push(spec.full);
+			}
+		}
+
+		// Create replacement imports
+		const newImports: string[] = [];
+		
+		if (coreSpecifiers.length > 0) {
+			newImports.push(`import { ${coreSpecifiers.join(", ")} } from "@lingui/core/macro"`);
+		}
+		
+		if (reactSpecifiers.length > 0) {
+			newImports.push(`import { ${reactSpecifiers.join(", ")} } from "@lingui/react/macro"`);
+		}
+
+		// If there are other specifiers, keep them with @lingui/macro for now
+		if (otherSpecifiers.length > 0) {
+			newImports.push(`import { ${otherSpecifiers.join(", ")} } from "@lingui/macro"`);
+		}
+
+		// Replace the original import with new imports
+		if (newImports.length > 0) {
+			edits.push(importNode.replace(newImports.join("\n")));
+		} else {
+			// If no recognized macros, remove the import
+			edits.push(importNode.replace(""));
+		}
+	}
 
 	const newSource = rootNode.commitEdits(edits);
 	return newSource;
+}
+
+// Helper function to parse import specifiers
+function parseImportSpecifiers(importsText: string): Array<{ name: string; full: string }> {
+	const specifiers: Array<{ name: string; full: string }> = [];
+	
+	// Remove curly braces and whitespace, then split by comma
+	const cleanText = importsText.replace(/[{}]/g, '').trim();
+	const parts = cleanText.split(",").map(part => part.trim());
+	
+	for (const part of parts) {
+		if (part.includes(" as ")) {
+			// Handle "name as alias" syntax
+			const [name, alias] = part.split(" as ").map(s => s.trim());
+			specifiers.push({ name, full: part });
+		} else {
+			// Handle simple name
+			specifiers.push({ name: part, full: part });
+		}
+	}
+	
+	return specifiers;
 }
 
 export default transform;

--- a/codemods/sample-jssg-codemod/tests/fixtures/expected.js
+++ b/codemods/sample-jssg-codemod/tests/fixtures/expected.js
@@ -1,3 +1,0 @@
-const oldVariable = "should be const"
-const anotherVar = 42
-console.log("debug statement"); 

--- a/codemods/sample-jssg-codemod/tests/lingui-macro-split/expected.ts
+++ b/codemods/sample-jssg-codemod/tests/lingui-macro-split/expected.ts
@@ -1,0 +1,31 @@
+// Test case: Mixed imports with both React and core macros
+import { t, plural } from "@lingui/core/macro"
+import { Trans, Plural } from "@lingui/react/macro"
+
+// Test case: Only core macros
+import { msg, select, i18n } from "@lingui/core/macro"
+
+// Test case: Only React macros
+import { Select, SelectOrdinal } from "@lingui/react/macro"
+
+// Test case: Aliased imports
+import { t as translate } from "@lingui/core/macro"
+import { Trans as Translation } from "@lingui/react/macro"
+
+// Test case: Only unrecognized imports (should keep with @lingui/macro)
+import { someUnknownMacro } from "@lingui/macro"
+
+// Usage examples
+const message = t`Hello world`;
+const pluralMessage = plural(count, {
+  one: "One item",
+  other: "# items"
+});
+
+const jsx = (
+  <Trans>Hello world</Trans>
+);
+
+const pluralJsx = (
+  <Plural value={count} one="One item" other="# items" />
+);

--- a/codemods/sample-jssg-codemod/tests/lingui-macro-split/input.ts
+++ b/codemods/sample-jssg-codemod/tests/lingui-macro-split/input.ts
@@ -1,0 +1,29 @@
+// Test case: Mixed imports with both React and core macros
+import { t, plural, Trans, Plural } from "@lingui/macro";
+
+// Test case: Only core macros
+import { msg, select, i18n } from "@lingui/macro";
+
+// Test case: Only React macros
+import { Select, SelectOrdinal } from "@lingui/macro";
+
+// Test case: Aliased imports
+import { t as translate, Trans as Translation } from "@lingui/macro";
+
+// Test case: Only unrecognized imports (should keep with @lingui/macro)
+import { someUnknownMacro } from "@lingui/macro";
+
+// Usage examples
+const message = t`Hello world`;
+const pluralMessage = plural(count, {
+  one: "One item",
+  other: "# items"
+});
+
+const jsx = (
+  <Trans>Hello world</Trans>
+);
+
+const pluralJsx = (
+  <Plural value={count} one="One item" other="# items" />
+);

--- a/codemods/sample-jssg-codemod/workflow.yaml
+++ b/codemods/sample-jssg-codemod/workflow.yaml
@@ -2,10 +2,10 @@ version: "1"
 
 nodes:
   - id: apply-transforms
-    name: Apply AST Transformations
+    name: Apply Lingui Macro Import Transformations
     type: automatic
     steps:
-      - name: "Scan typescript files and apply fixes"
+      - name: "Scan TypeScript/JavaScript files and migrate @lingui/macro imports"
         js-ast-grep:
           js_file: scripts/codemod.ts
           language: "typescript"


### PR DESCRIPTION
- Transform @lingui/macro imports to split @lingui/react/macro and @lingui/core/macro
- Handle React macros (Trans, Plural, Select, etc.) → @lingui/react/macro
- Handle core macros (t, msg, plural, etc.) → @lingui/core/macro
- Support aliased imports and preserve unrecognized imports
- Add comprehensive test coverage with lingui-macro-split test case
- Update codemod metadata and workflow configuration

Resolves migration from deprecated @lingui/macro to Lingui v5 split packages

re: #1 